### PR TITLE
Native-Support: Avoid Noodle Dimming

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,7 @@ bl_info = {
     "author" : "Binit",
     "description" : "Takes high quality screenshot of a node tree",
     "blender" : (3, 1, 0),
-    "version" : (1, 1, 7),
+    "version" : (1, 1, 8),
     "location" : "Node Editor > Context Menu (Right Click)",
     "warning" : "",
     "category" : "Node"

--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,7 @@ bl_info = {
     "author" : "Binit",
     "description" : "Takes high quality screenshot of a node tree",
     "blender" : (3, 1, 0),
-    "version" : (1, 1, 6),
+    "version" : (1, 1, 7),
     "location" : "Node Editor > Context Menu (Right Click)",
     "warning" : "",
     "category" : "Node"
@@ -289,7 +289,7 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
         return {'RUNNING_MODAL'}
 
     def cancel(self, context):
-        
+
         if self.forced_cancel: 
             PrintNodesPopUp(message = "Process Force Cancelled", icon = "CANCEL")
 

--- a/__init__.py
+++ b/__init__.py
@@ -213,7 +213,8 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
         
         return Xmin, Ymin, Xmax, Ymax
 
-    def modal(self, context, event): 
+    def modal(self, context, event):
+        context.window.cursor_set("STOP")
         if event.type in {'RIGHTMOUSE', 'ESC'}: # force cancel
             self.forced_cancel = True
             self.cancel(context)
@@ -245,6 +246,7 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
         return {'PASS_THROUGH'} # pass for next iteration
 
     def execute(self, context):
+        context.window.cursor_set("STOP")
         self.store_current_settings(context)
         self.set_settings_for_screenshot(context)
 
@@ -303,7 +305,7 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
 
         wm = context.window_manager
         wm.event_timer_remove(self._timer)
-
+        context.window.cursor_set("DEFAULT")
 
 def TrimImage(img:Image.Image):
     '''function to trim out empty space from the edges, leaving a padding (as defined in preferences)

--- a/__init__.py
+++ b/__init__.py
@@ -87,6 +87,8 @@ class PRTND_PT_Preferences(AddonPreferences): # setting up perferences
         size=3,
         subtype='COLOR',
         default=[0.0,0.0,0.0],
+        soft_max=1.0,
+        soft_min=0.0,
     )
 
     disable_auto_crop: BoolProperty(

--- a/__init__.py
+++ b/__init__.py
@@ -130,8 +130,8 @@ def PrintNodesPopUp(message = "", title = "PrintNodes PopUp", icon = ""): # func
     bpy.context.window_manager.popup_menu(draw, title = title, icon = icon)
 
 def select_nodes(nodes,select = True):
-    for node in nodes:
-        node.select = select
+    for current_node in nodes:
+        current_node.select = select
 
 # bpy.ops.node.select_all(action='SELECT')
 
@@ -241,8 +241,9 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
         # co-ords from node.location and tree.view_center are apparently not the same (you could say they don't co-ordinate, haha ha...) so I have to make sure I'm using the right ones 
         node = tree.nodes.new("NodeReroute")
         node.location = self.Xmax, self.Ymax
-        for current_node in nodes:
-            current_node.select = False
+        select_nodes(nodes,select=False)
+        # for current_node in nodes:
+        #     current_node.select = False
         node.select = True
         bpy.ops.wm.redraw_timer(iterations=1)
         bpy.ops.node.view_selected()
@@ -253,8 +254,7 @@ class PRTND_OT_ModalScreenshotTimer(Operator): # modal operator to take parts of
 
         node = tree.nodes.new("NodeReroute")
         node.location = self.Xmin, self.Ymin
-        for current_node in nodes:
-            current_node.select = False
+        select_nodes(nodes,select=False)
         node.select = True
         bpy.ops.wm.redraw_timer(iterations=1)
         bpy.ops.node.view_selected() # also align view to the (bottom-left) corner node. As an initial point for the screenshotting process


### PR DESCRIPTION
A Noodle gets dimmed if none of the nodes on both ends are visible or selected. This ruins the screenshot and to get a proper screenshot requires a separate custom build. Link : [Custom Build](https://github.com/b-init/PrintNodes/releases/download/v1.1.5/Blender3.3ForPrintNodes.zip) 
Noodle does not get dimmed if one of the node on its end is selected. So to avoid noodle dimming we just select all the nodes. But active node and selected nodes have a distinctive outline. The Noodles also have the outline when node is selected.
![image](https://user-images.githubusercontent.com/45537313/201135206-832d00b0-f276-4d29-a5ff-e003bd873430.png)

We change the outline colors of the active and selected nodes in Preferences to match node's outline in the regular state(where it is neither selected nor active). In Blender's default theme "Blender Dark" the setting node outline color to Black works. For other themes, the option is provided to change the outline color. In any case, we hide the outline of noodles by setting alpha to 0. 
We restore all the settings to their previous state after the screenshot.


### Code Cleanup:


reduced complexity of `execute` function of the Modal Operator by creating new functions to perform a single task instead of doing everything in the execute function. Also added type definition and docstring to `TrimImage`
New functions are:
- store_current_settings(self, context):
- restore_settings(self, context):
- set_settings_for_screenshot(self, context):
- find_min_max_coords(self, nodes)->tuple[float]:
